### PR TITLE
14 create release artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ before_install:
   - cp .travis.settings.xml $HOME/.m2/settings.xml
   - curl ifconfig.co|xargs echo "Travis IP address is ";
 
-after_success:
+
+script:
+  - mvn test -B
   # Only release on master builds
   - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     git config --global set user.email "travis@travis-ci.org";

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
+[![Build Status](https://travis-ci.org/ONSdigital/rm-common-config.svg?branch=master)](https://travis-ci.org/ONSdigital/rm-common-config)
+
 # rm-common-config
 Common configuration for Response Management.


### PR DESCRIPTION
Release in script phase
    
If we do the release in the after_success phase of travis and there is a
failure the build will still be marked as success. See
https://docs.travis-ci.com/user/customizing-the-build/#Breaking-the-Build
    
This change moves the release to the script phase which will cause travis to fail.