### PR TITLE
Remove duplicate repository id

### DIFF
--- a/.travis.settings.xml
+++ b/.travis.settings.xml
@@ -26,7 +26,7 @@
                     <snapshots>
                         <enabled>false</enabled>
                     </snapshots>
-                    <id>central</id>
+                    <id>maven-central</id>
                     <name>Central Repository</name>
                     <url>https://repo.maven.apache.org/maven2</url>
                 </repository>


### PR DESCRIPTION
To fix warnings
```
[WARNING] 
[WARNING] Some problems were encountered while building the effective settings
[WARNING] 'profiles.profile[artifactory].repositories.repository.id' must be unique but found duplicate repository with id central @ /home/travis/.m2/settings.xml
[WARNING] 
```