### PR TITLE
Allow ignoring of checkstyle

### DIFF
--- a/checkstyle/ons-checkstyle-config.xml
+++ b/checkstyle/ons-checkstyle-config.xml
@@ -214,5 +214,11 @@
       <property name="exceptionVariableName" value="expected"/>
     </module>
     <module name="CommentsIndentation"/>
+    <!-- Ignore checkstyle with: // CHECKSTYLE IGNORE check FOR NEXT 1 LINES -->
+    <module name="SuppressWithNearbyCommentFilter">
+      <property name="commentFormat" value="CHECKSTYLE IGNORE (\w+) FOR NEXT (\d+) LINES"/>
+      <property name="checkFormat" value="$1"/>
+      <property name="influenceFormat" value="$2"/>
+    </module>
   </module>
 </module>


### PR DESCRIPTION
# Motivation and Context
In some cases the checkstyle needs to be worked around where naming
conventions may cause breaking API changes or the checkstyle deviates
from the code formatter where the checkstyle cannot be updated to
reflect the code style.

This change allows you to add a comment in the bit of code the
checkstyle is failing to ignore certain rules e.g.
```java
  // CHECKSTYLE IGNORE Indentation FOR NEXT 1 LINES
```

# What has changed
* Added SuppressWithNearbyCommentFilter module to checkstyle

# How to test?
1. Change the checkstyle config to the local copy so it won't fetch it from github
	```xml
              <configuration>
                <configLocation>/Users/path-to-source/ons-checkstyle-config.xml</configLocation>
                <encoding>UTF-8</encoding>
                <consoleOutput>true</consoleOutput>
                <violationSeverity>info</violationSeverity>
              </configuration>
	```
1. Build the rm-common-config project locally
1. Go into the rm-case-service and checkout the branch format-java-code
1. Bump the parent pom version to 10.49.12-SNAPSHOT
	```xml
    <parent>
        <groupId>uk.gov.ons.ctp.product</groupId>
        <artifactId>rm-common-config</artifactId>
        <version>10.49.12-SNAPSHOT</version>
    </parent>
	```
1. Run `mvn install` observing no error
1. Cause a checkstyle issue by removing the ignore comment https://github.com/ONSdigital/rm-case-service/blob/format-java-code/src/main/java/uk/gov/ons/ctp/response/casesvc/domain/model/CaseReport.java#L26
1. Run `mvn install` observing error

# Links
https://trello.com/c/YUQ48iFw/172-automagically-format-code