### PR TITLE
Added Godaddy logger to dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>uk.gov.ons.ctp.product</groupId>
   <artifactId>rm-common-config</artifactId>
-  <version>10.49.14</version>
+  <version>10.49.13-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>CTP SDC Dependencies</name>
   <description>CTP SDC Dependencies</description>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>uk.gov.ons.ctp.product</groupId>
   <artifactId>rm-common-config</artifactId>
-  <version>10.49.13-SNAPSHOT</version>
+  <version>10.49.14</version>
   <packaging>pom</packaging>
   <name>CTP SDC Dependencies</name>
   <description>CTP SDC Dependencies</description>
@@ -35,6 +35,7 @@
     <java.version>1.8</java.version>
     <orika.version>1.5.1</orika.version>
     <surefire.version>2.20</surefire.version>
+    <godaddylogging.version>1.2.5</godaddylogging.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
@@ -115,6 +116,12 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-csv</artifactId>
         <version>1.4</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.godaddy</groupId>
+        <artifactId>logging</artifactId>
+        <version>${godaddylogging.version}</version>
       </dependency>
 
 


### PR DESCRIPTION
# Motivation and Context
Rolling out Godaddy logger to all the Java services, in line with the spike that was already done on the IAC service.

# What has changed
Added Godaddy logger to the list of dependencies in the parent pom.

# How to test?
Build it. Can't be tested as this is just a configuration project.

# Links
Trello: https://trello.com/c/PtPEefYE/334-spike-ensure-iac-java-service-conforms-to-standardised-logging-format-1-day

Trello: https://trello.com/c/2cLIClJa/348-roll-out-godaddy-logger-to-all-the-other-java-services

IAC Service PR: https://github.com/ONSdigital/iac-service/pull/19